### PR TITLE
H2Lib updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ If you want to contribute to this list (please do), send me a pull request or co
 ### [Hlib](http://hlib.org/) Lars Grasedyck and Steffen Börm (Leipzig, Max Planck Institute)
 - Source code available through signed license agreement.
 - Hierarchical format: H and H^2
+- 
+### [H2Lib] (https://github.com/H2Lib/H2Lib) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
+- Open source
+- Hierarchical format: H and H^2
 
 
 
@@ -32,10 +36,6 @@ If you want to contribute to this list (please do), send me a pull request or co
 ### [Dense_HODLR] (https://github.com/amiraa127/Dense_HODLR) Amirhossein Aminfar (Stanford University)
 - Open source
 - Hierarchical format: HODLR
-
-### [H2Lib] (https://github.com/H2Lib/H2Lib) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
-- Open source
-- Hierarchical format: H^2
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 - Source code available through signed license agreement.
 - Hierarchical format: H and H^2
 
-### [H2Lib] (hhttp://www.h2lib.org/) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
+### [H2Lib] (http://www.h2lib.org/) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
 - Open source
 - Hierarchical format: H and H^2
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 ### [Hlib](http://hlib.org/) Lars Grasedyck and Steffen Börm (Leipzig, Max Planck Institute)
 - Source code available through signed license agreement.
 - Hierarchical format: H and H^2
-- 
+
 ### [H2Lib] (https://github.com/H2Lib/H2Lib) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
 - Open source
 - Hierarchical format: H and H^2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 - Source code available through signed license agreement.
 - Hierarchical format: H and H^2
 
-### [H2Lib] (https://github.com/H2Lib/H2Lib) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
+### [H2Lib] (hhttp://www.h2lib.org/) Steffen Boerm, Knut Reimer, Dirk Boysen, Sven Christophersen, Nadine Albrecht, and Jens Burmeister.  (University of Kiel)
 - Open source
 - Hierarchical format: H and H^2
 


### PR DESCRIPTION
I noticed that H2Lib was listed under __C++__. To my best knowledge this lib is written in __C__. Also, it supports _both_ H and H^2 formats and has a website besides the github rep.