### PR TITLE
Update README.md to use GitHubs support for LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Curated list of [Hierarchical Matrices](http://en.wikipedia.org/wiki/Hierarchica
 
 ### [HLIBpro](http://www.hlibpro.com) Ronald Kriemann (Leipzig, Max Planck Institute)
 - Binary files only, distributed memory implementation on MPI, on shared memory based on TBB
-- Hierarchical format: $\mathcal{H}$ and $\mathcal{H}$
+- Hierarchical format: $\mathcal{H}$ and $\mathcal{H}^2$
 
 ### [AHMED](https://github.com/xantares/ahmed) Mario Bebendorf and Sergej Rjasanow (University of Bonn) 
 - Source code available through online license agreement.


### PR DESCRIPTION
Using the fact that GitHub now supports LaTeX (before it used rendered images from codecogs).

This switch makes it possible to see the mathematical expression even if dark mode is used.